### PR TITLE
Azure IoT branding updates

### DIFF
--- a/_docs/Azure/Data, Analytics, and AI/Azure Percept.md
+++ b/_docs/Azure/Data, Analytics, and AI/Azure Percept.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Azure Percept
-description: Resources for AI/IOT with Azure Percept
+description: Resources for AI/IoT with Azure Percept
 updated: 2022-04-27
 permalink: /azure/data-analytics-ai/azure-percept
 tags: 

--- a/_docs/Azure/IoT/AzureDigitalTwins.md
+++ b/_docs/Azure/IoT/AzureDigitalTwins.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Azure Digital Twins
-description: Resources for Azuer Digital Twins
+description: Resources for Azure Digital Twins
 updated: 2022-01-31
 permalink: /azure/iot/iot-adt
 tags: 

--- a/_docs/Azure/IoT/IoT Central.md
+++ b/_docs/Azure/IoT/IoT Central.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: IoT Central
-description: Resources for IoT Central
+title: Azure IoT Central
+description: Resources for Azure IoT Central
 updated: 2021-12-01
 permalink: /azure/iot/iot-central
 tags: 
@@ -10,7 +10,7 @@ tags:
 - iot
 ---
 
-# Learning Plan Resources for IoT Central
+# Learning Plan Resources for Azure IoT Central
 
 ## Keeping Up
 

--- a/_docs/Azure/IoT/IoT Edge.md
+++ b/_docs/Azure/IoT/IoT Edge.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: IoT Edge
-description: Resources for IoT Edge
+title: Azure IoT Edge
+description: Resources for Azure IoT Edge
 updated: 2021-12-01
 permalink: /azure/iot/iot-edge
 tags: 
@@ -10,7 +10,7 @@ tags:
 - iot
 ---
 
-# Learning Plan Resources for IoT Edge
+# Learning Plan Resources for Azure IoT Edge
 
 ## Keeping Up
 

--- a/_docs/Azure/IoT/IoT Hub.md
+++ b/_docs/Azure/IoT/IoT Hub.md
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: IoT Hub
-description: Resources for IoT Hub
+title: Azure IoT Hub
+description: Resources for Azure IoT Hub
 updated: 2021-12-01
 permalink: /azure/iot/iot-hub
 tags: 
@@ -10,7 +10,7 @@ tags:
 - iot
 ---
 
-# Learning Plan Resources for IoT Hub
+# Learning Plan Resources for Azure IoT Hub
 
 ## Keeping Up
 

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -87,9 +87,9 @@ Virtual Training Series events focuses on enabling our partners at scale on spec
 ### IoT
 
 * [Azure Digital Twins](/LearningPlanResources/Azure/IoT/AzureDigitalTwins.md)
-* [IoT Edge](/LearningPlanResources/Azure/IoT/IoT%20Edge.md)
-* [IoT Central](/LearningPlanResources/Azure/IoT/IoT%20Central.md)
-* [IoT Hub](/LearningPlanResources/Azure/IoT/IoT%20Hub.md)
+* [Azure IoT Edge](/LearningPlanResources/Azure/IoT/IoT%20Edge.md)
+* [Azure IoT Central](/LearningPlanResources/Azure/IoT/IoT%20Central.md)
+* [Azure IoT Hub](/LearningPlanResources/Azure/IoT/IoT%20Hub.md)
 
 ## Business Applications
 


### PR DESCRIPTION
Added "Azure" to "IoT" when referring to our products