### PR TITLE
Update Onboarding Module

### DIFF
--- a/_docs/Skilling/Partner Onboarding Academy/Accelerate.md
+++ b/_docs/Skilling/Partner Onboarding Academy/Accelerate.md
@@ -2,7 +2,7 @@
 layout: page
 title: Accelerate
 description: Accelerate your business
-updated: 2024-02-22
+updated: 2024-09-06
 permalink: /skilling/partner-onboarding-academy/accelerate
 showbreadcrumb: true
 ---
@@ -16,8 +16,13 @@ The Microsoft Partner Onboarding Academy's **Modules** are organized into sectio
 
 **Accelerating your Co-Sell journey with Microsoft involves a strategic approach to collaborating with Microsoft's sales teams to drive joint revenue.**
 
-Here are several steps to accelerate your Co-Sell journey:
+To accelerate your Co-sell journey, focus on the following actions.
 
-* [Access Partner Incentives](https://partner.microsoft.com/en-US/partnership/partner-incentives)
-* [Improve your Partner Capability Score](https://learn.microsoft.com/en-us/partner-center/partner-capability-score)
-* [Microsoft Partner Blog](https://blogs.partner.microsoft.com/partner/)
+1. Create and maintain a current business profile on AppSource
+1. Earn Solution Partner Designations and Specializations
+  - [Improve your Partner Capability Score](https://learn.microsoft.com/en-us/partner-center/membership/partner-capability-score)
+1. Accept and send customer referrals in Partner Center
+1. Utilize Microsoft incentive programs to win opportunities and accelerate consumption
+  - [Access Partner Incentives](https://aka.ms/partnerincentives)
+
+To view the latest partner information, check out the [Microsoft Partner Blog](https://blogs.partner.microsoft.com/partner/).

--- a/_docs/Skilling/Partner Onboarding Academy/Acronyms.md
+++ b/_docs/Skilling/Partner Onboarding Academy/Acronyms.md
@@ -2,7 +2,7 @@
 layout: page
 title: Acronyms
 description: Common Acronyms
-updated: 2023-11-14
+updated: 2024-09-06
 permalink: /skilling/partner-onboarding-academy/acronyms
 showbreadcrumb: true
 ---
@@ -10,12 +10,12 @@ showbreadcrumb: true
 
 Below are acronyms and definitions used in the Partner Onboarding Academy:
 
-- **[CSP](https://learn.microsoft.com/en-us/partner-center/enrolling-in-the-csp-program)**: Cloud Service Providers
+- **[CSP](https://learn.microsoft.com/en-us/partner-center/enrolling-in-the-csp-program)**: Cloud Solution Providers
 - **[ECIF](https://partner.microsoft.com/en-bd/community/seanm-partner-hub/intelligent-cloud/funding)**: End Customer Investment Funds
 - **[GTM](https://en.wikipedia.org/wiki/Go_to_market)**: Go-To-Market
 - **[ISV](https://en.wikipedia.org/wiki/Independent_software_vendor)**: Independent Software Vendor
 - **[MACC](https://learn.microsoft.com/en-us/partner-center/marketplace/azure-consumption-commitment-enrollment)**: Microsoft Azure Consumption Commitment
-- **[MCPP](https://www.microsoft.com/en-us/us-partner-blog/2022/06/01/what-you-need-to-know-about-the-microsoft-cloud-partner-program/)**: Microsoft Cloud Partner Program
+- **[MAICPP](https://partner.microsoft.com/en-US/blog/article/fueling-partner-growth-and-profitability-in-the-era-of-ai)**: Microsoft AI Cloud Partner Program
 - **[MP](https://azuremarketplace.microsoft.com/en-us/)**: Azure Marketplace
 - **[MPO](https://learn.microsoft.com/en-us/partner-center/marketplace/multiparty-private-offers-faq)**: Multiparty Private Offers
 - **[MPN](https://partner.microsoft.com/en-us/partnership)**: Microsoft Partner Number

--- a/_docs/Skilling/Partner Onboarding Academy/Build.md
+++ b/_docs/Skilling/Partner Onboarding Academy/Build.md
@@ -26,7 +26,7 @@ For more information on Technical Presales and Deployment Benefits for Microsoft
 
 ### Technical Benefits
 
-Microsoft Partners may receive additional benefits from their partnership, including Azure Credits, Visual Studio and GitHub subscripttions, or other Microsoft software.
+Microsoft Partners may receive additional benefits from their partnership, including Azure Credits, Visual Studio and GitHub subscriptions, or other Microsoft software.
 
 #### Azure Credits
 

--- a/_docs/Skilling/Partner Onboarding Academy/Build.md
+++ b/_docs/Skilling/Partner Onboarding Academy/Build.md
@@ -2,7 +2,7 @@
 layout: page
 title: Build
 description: Build your solution on top of Azure
-updated: 2024-02-22
+updated: 2024-09-06
 permalink: /skilling/partner-onboarding-academy/build
 showbreadcrumb: true
 ---
@@ -26,17 +26,17 @@ For more information on Technical Presales and Deployment Benefits for Microsoft
 
 ### Technical Benefits
 
-Microsoft Partners can receive several benefits from their partnership, including Azure Credits, Visual Studio, other Microsoft software, and GitHub Enterprise licenses.
+Microsoft Partners may receive additional benefits from their partnership, including Azure Credits, Visual Studio and GitHub subscripttions, or other Microsoft software.
 
 #### Azure Credits
 
-As a Microsoft Partner, you may be eligible for Azure credits issued each month or for the current year. You can view your credits at the **[Partner Center Azure Credits Page](https://partner.microsoft.com/dashboard/v2/benefits/azure).** Assign these credits to a user in your organization.
+As a Microsoft Partner, you may be eligible for monthly or one-time Azure credits. You can view your credits at the **[Partner Center Azure Credits Page](https://partner.microsoft.com/dashboard/v2/benefits/azure).** Assign these credits to a user in your organization.
 
 For more information on Azure Credits for Microsoft Partners, see **[this article](https://learn.microsoft.com/en-us/partner-center/mpn-benefits-azure-cloud).**
 
 #### Software
 
-Microsoft Partners receive licenses for free Microsoft software. These benefits are listed in the "Software Benefits" section of **[Partner Center](https://partner.microsoft.com/dashboard/home)**, along with license keys, the last date you may activate the software, and instructions on activating your software.
+Microsoft Partners may receive Internal Use Rights (IUR) licenses Microsoft software. These benefits are listed in the "Software Benefits" section of **[Partner Center](https://partner.microsoft.com/dashboard/home)**, along with license keys, the last date you may activate the software, and instructions on activating your software.
 
 For more information on Software Benefits for Microsoft Partners, see **[this article](https://learn.microsoft.com/en-us/partner-center/mpn-benefits-software).**
 
@@ -48,6 +48,16 @@ To access these benefits, select "Visual Studio subscriptions benefits" on the "
 
 See **[this article](https://learn.microsoft.com/en-us/partner-center/mpn-benefits-visual-studio)** for more information on Visual Studio and GitHub benefits for Microsoft Partners.
 
+### Build Skills
+
+- Review the [Partner Skilling events calendar](https://assetsprod.microsoft.com/mpn/microsoft-partner-training-calendar.pdf)
+- Subscribe to the [Partner Skilling newsletter](https://aka.ms/PartnerSkillingNewsletter)
+- Bookmark the [Microsoft Partner Training resources](https://partner.microsoft.com/training)
+- Join an upcoming **[Sales & Pre-Sales Skilling Bootcamp](https://vshow.on24.com/vshow/FY24_SBcamp/registration/23189?partnerref=SEBTCP_ALL_ORG_OTH_PNSKP)** or watch a past bootcamp
+- Build advanced technical skills to be **Project Ready** in [Azure](https://vshow.on24.com/vshow/FY24_AZDepth/registration/23172?partnerref=DP_AZ_ORG_OTH_PN), [Security](https://vshow.on24.com/vshow/FY24_SDepth/registration/23173?partnerref=DP_SCI_ORG_OTH_PN), [Modern Work](https://vshow.on24.com/vshow/FY24_MWCWeek/registration/23378?partnerref=DP_MW_ORG_OTH_PNSKP), or [Business Applications](https://vshow.on24.com/vshow/FY24_BADepth/registration/23174?partnerref=DP_BA_ORG_OTH_PN)
+- Attend an upcoming **Certification Week** for [Azure](https://vshow.on24.com/vshow/FY24_ACWeek/registration/23191?partnerref=CW_AZ_ORG_OTH_PN), [Security](https://vshow.on24.com/vshow/FY24_SCWeek/registration/23187?partnerref=CW_SCI_ORG_OTH_PN), [Modern Work](https://vshow.on24.com/vshow/FY24_MWCWeek/registration/23184?partnerref=CW_MW_ORG_OTH_PN), or [Business Applications](https://vshow.on24.com/vshow/FY24_BACWeek/registration/23188?partnerref=CW_BA_ORG_OTH_PN)
+- Explore additional [Partner Skilling Academies](/PartnerResources/skilling/academies) on this site
+
 ### Useful Links
 
 - [Use Technical Presales & Deployment Services Consulting (TDP)](https://learn.microsoft.com/en-us/partner-center/technical-benefits)
@@ -57,9 +67,9 @@ See **[this article](https://learn.microsoft.com/en-us/partner-center/mpn-benefi
   - [Visual Studio & GitHub](https://learn.microsoft.com/en-us/partner-center/mpn-benefits-visual-studio)
 - Build Skills
   - [Use Skills Navigator](https://learn.microsoft.com/en-us/collections/mjdcwo2gzmz43)
-  - [Find a Solution Partner](https://partner.microsoft.com/en-rs/partnership/solutions-partner) **(OPTIONAL)**
+  - [Earn a Solution Partner Designation](https://partner.microsoft.com/en-us/partnership/solutions-partner) **(OPTIONAL)**
 - Build on Azure
-  - [Mastering the Marketplace](https://microsoft.github.io/Mastering-the-Marketplace/)
+  - [Mastering the Marketplace](https://aka.ms/MasteringTheMarketplace)
 - [Technical Journeys](https://partner.microsoft.com/en-US/partnership/technical-journeys) — Webinars and technical consultations to help you grow
 
 ### Next Steps

--- a/_docs/Skilling/Partner Onboarding Academy/Create Offer.md
+++ b/_docs/Skilling/Partner Onboarding Academy/Create Offer.md
@@ -3,7 +3,7 @@ layout: page
 title: Create an Offer
 description: Are you ready to create an offer?
 permalink: /skilling/partner-onboarding-academy/create-offer
-updated: 2023-11-14
+updated: 2024-09-06
 showbreadcrumb: true
 tags: 
 - academy content
@@ -37,7 +37,7 @@ To Create an Offer, you must select the following:
     - [Subscription](https://learn.microsoft.com/en-us/partner-center/marketplace/determine-your-listing-type#subscription): Charge a flat fee for monthly or annual subscriptions
     - [Usage Based Pricing](https://learn.microsoft.com/en-us/partner-center/marketplace/determine-your-listing-type#usage-based-pricing): Used to define custom or pre-defined billing metrics and rates (e.g., per vCPU, per seat, usage billing, etc.)
  
-__PRO TIP__: Most partners start with the "Contact Me" offer when getting started.
+> 💡 **TIP**: Most partners start with the "Contact Me" offer when getting started.
 
 ### Offer Types
 
@@ -49,7 +49,7 @@ __PRO TIP__: Most partners start with the "Contact Me" offer when getting starte
 - [Azure Applications](https://learn.microsoft.com/en-us/partner-center/marketplace/plan-azure-application-offer)
 - [Dynamics 365](https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-dynamics-365)
 - [Managed Service](https://learn.microsoft.com/en-us/partner-center/marketplace/plan-managed-service-offer)
-- [Consulting Service](https://learn.microsoft.com/en-us/partner-center/marketplace/plan-consulting-service-offer)
+- [Professional Service](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/plan-professional-service-offer)
 - [And more!](https://learn.microsoft.com/en-us/partner-center/marketplace/publisher-guide-by-offer-type#list-of-offer-types)
 
 #### [Offer Type — SaaS](https://learn.microsoft.com/en-us/partner-center/marketplace/plan-saas-offer)
@@ -75,4 +75,4 @@ When creating an offer, you may want to offer different pricing models for custo
 
 A guide that compares the two options can be found **[here](https://learn.microsoft.com/en-us/partner-center/marketplace/isv-customer-faq).**
 
-__PRO TIP__: When possible, use a Private Offer. Creating a Private Plan requires your offer to go through certification again and takes more time.
+> 💡 **TIP**: When possible, use a Private Offer. Creating a Private Plan requires your offer to go through certification again and takes more time.

--- a/_docs/Skilling/Partner Onboarding Academy/FAQ.md
+++ b/_docs/Skilling/Partner Onboarding Academy/FAQ.md
@@ -15,12 +15,17 @@ tags:
 
 ### Frequently Asked Questions
 
-- What's the best way to get support? If you encounter issues and need to contact support, see [this page for which portal you should use](https://learn.microsoft.com/en-us/partner-center/support-resource-options).
+- **What's the best way to get support?**<br>
+If you encounter issues and need to contact support, see [this page for which portal you should use](https://learn.microsoft.com/en-us/partner-center/support-resource-options).
 
-- Does the Marketplace have a fee? [Yes, 3% if transacting through the MP](https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-commercial-transaction-capabilities-and-considerations#commercial-marketplace-service-fees)
+- **Does the Marketplace have a fee?**<br>
+[Yes, 3% if transacting through the MP](https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-commercial-transaction-capabilities-and-considerations#commercial-marketplace-service-fees)
 
-- Does becoming a Microsoft Partner mean that Microsoft owns part of your IP? No.
+- **Does becoming a Microsoft Partner mean that Microsoft owns part of your IP?**<br>
+No.
 
-- Can you be a Microsoft partner if you sell products? If there is software tied to the product then you can sell the software through the Marketplace and partner with Microsoft. However, hardware or any physical product cannot be transacted through the Marketplace.
+- **Can you be a Microsoft partner if you sell products?**<br>
+ If there is software tied to the product then you can sell the software through the Marketplace and partner with Microsoft. However, hardware or any physical product cannot be transacted through the Marketplace.
 
-- What do I do if I have a question not answered here? Join the [Marketplace Office Hours](https://microsoftcloudpartner.eventbuilder.com/MarketplaceOverviewandQAforPartners).
+- **What do I do if I have a question not answered here?**<br>
+Join the [Marketplace Office Hours](https://microsoftcloudpartner.eventbuilder.com/MarketplaceOverviewandQAforPartners).

--- a/_docs/Skilling/Partner Onboarding Academy/Grow.md
+++ b/_docs/Skilling/Partner Onboarding Academy/Grow.md
@@ -2,7 +2,7 @@
 layout: page
 title: Grow
 description: Grow your Marketplace Offers
-updated: 2024-02-22
+updated: 2024-09-06
 permalink: /skilling/partner-onboarding-academy/grow
 showbreadcrumb: true
 ---
@@ -14,7 +14,7 @@ The Microsoft Partner Onboarding Academy's **Modules** are organized into sectio
 
 ![](../../../assets/partner-onboarding/partner-journey-grow.png)
 
-**After publishing an offer to the Marketplace, your next step will be to grow adoption and Co-Selling. These three steps will make your offer attractive to potential customers:**
+**After publishing an offer to the Marketplace, your next step will be to grow adoption and Co-Selling. These three steps for ISV partners will make your offer attractive to potential customers:**
 
 - **[Create A Transactable Offer](/PartnerResources/skilling/partner-onboarding-academy/transactable-offer):** Transactable Offers are the first step towards Co-Selling with Microsoft.
 - **[Update Offer to be IP Co-Sell Eligible](/PartnerResources/skilling/partner-onboarding-academy/cosell):** Make your offer more attractive to customers and Microsoft field-sellers by making your offer **[IP Co-Sell Eligible](https://learn.microsoft.com/en-us/partner-center/co-sell-requirements#requirements-for-azure-ip-co-sell-eligible-status).**

--- a/_docs/Skilling/Partner Onboarding Academy/Market.md
+++ b/_docs/Skilling/Partner Onboarding Academy/Market.md
@@ -2,7 +2,7 @@
 layout: page
 title: Market
 description: Create your Marketplace Offer
-updated: 2024-02-22
+updated: 2024-09-06
 permalink: /skilling/partner-onboarding-academy/market
 showbreadcrumb: true
 ---
@@ -38,16 +38,15 @@ For additional details, see: **[Determine Offer Type and Pricing Plan](https://l
 
 | Offer Type   | Description |
 | ----------- | ----------- |
-| [IoT Edge Module](https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-iot-edge) | Azure IoT Edge modules are the smallest computation units managed by IoT Edge and can contain Microsoft services (such as Azure Stream Analytics), 3rd-party services, or your own solution-specific code. |
 | [Dynamics 365](https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-dynamics-365) | An AppSource offer that builds on or extends Dynamics 365 Business Central, Dynamics 365 Customer Engagement, Power Apps, and Finance and Operations apps. |
+| [Microsoft 365](https://learn.microsoft.com/en-us/partner-center/marketplace/why-publish | An AppSource offer that builds on or extends Microsoft 365. |
 | [Power BI App](https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-power-bi) | An AppSource offer that builds on or extends Power BI. |
-| [Consulting Service](https://learn.microsoft.com/en-us/partner-center/marketplace/plan-consulting-service-offer) | An offer to connect customers with services to support and extend their use of Azure, Dynamics 365, or Power Suite services, and Teams. |
+| [Professional Service](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/plan-professional-service-offer) | An offer to connect customers with services to support and extend their use of Azure, Dynamics 365, Microsoft 365 or Power Suite services. |
 | [Managed Service](https://learn.microsoft.com/en-us/partner-center/marketplace/plan-managed-service-offer) | An offer that allows a partner to manage customer-delegated subscriptions or resource groups through Azure Lighthouse. |
 
 Once you have identified the correct offer type for your solution, follow the respective **[Publishing Guide by Offer Type](https://learn.microsoft.com/en-us/partner-center/marketplace/publisher-guide-by-offer-type).**
 
-
-
+#### Listing Options
 
 Some Offer Types have different listing options available. For example, if you are publishing a SaaS offer, there are the following listing options:
        
@@ -58,9 +57,9 @@ Some Offer Types have different listing options available. For example, if you a
 | Get it now (Free) | The customer is redirected to your target URL  via Azure Active Directory (Azure AD). You can change to a different listing option after publishing the offer. |
 | Sell through Microsoft | Offers sold through Microsoft are called **transactable offers.** An offer that is transactable is one in which Microsoft facilitates the exchange of money for a software license on the publisher's behalf. Microsoft bills SaaS offers using the pricing model you choose and manages customer transactions on your behalf. Azure infrastructure usage fees are billed to you, the partner, directly. You should account for infrastructure costs in your pricing model. This is explained in more detail in the SaaS billing below. |  
 
-NOTE: You cannot change this option once your offer is published.
+> ⚠️ **WARNING**: You cannot change this option once your offer is published.
 
-**TIP: The fastest and easiest offer is "Contact me." If your goal is to get an offer published on the Azure Marketplace quickly then select a "Contact Me" offer.** However, most of the Co-Sell and GTM benefits provided by Microsoft require solutions to be transactable in the Azure Marketplace. This would require a "Sell With Microsoft" offer.
+> 💡 **TIP**: The fastest and easiest offer is "Contact me." **If your goal is to get an offer published on the Azure Marketplace quickly, then select a "Contact Me" offer.** However, most of the Co-Sell and GTM benefits provided by Microsoft require solutions to be transactable in the Azure Marketplace. This would require a "Sell With Microsoft" offer.
 
 For a deeper dive into creating an offer, see **[Create Offer Page](/PartnerResources/skilling/partner-onboarding-academy/create-offer).**
 
@@ -76,37 +75,37 @@ For a deeper dive into creating an offer, see **[Create Offer Page](/PartnerReso
     
 When you choose to Co-Sell an offer, you can work directly with Microsoft sales teams and Microsoft partners on joint selling opportunities. That unlocks benefits when selling through the commercial marketplace online stores: Azure Marketplace and the Microsoft Commercial Marketplace.
 
-Follow **[this guide](https://learn.microsoft.com/en-us/partner-center/co-sell-configure)** to configure your Co-Sell Solution.
+Follow **[this guide](https://learn.microsoft.com/en-us/partner-center/referrals/co-sell-configure)** to configure your Co-Sell Solution.
 
 - There are 3 required documents needed to Co-Sell with Microsoft.  
-    - Solution One Pager  
-    - Solution Pitch Deck   
+    - Solution One Pager
+    - Solution Pitch Deck
     - Reference Architecture *(SaaS Offers Only)*
     
-Templates for the required documents can be found **[here](https://learn.microsoft.com/en-us/partner-center/co-sell-configure#documents-that-support-co-sell).**
+Templates for the required documents can be found **[here](https://learn.microsoft.com/en-us/partner-center/referrals/co-sell-configure#documents-that-support-co-sell).**
 
-#### Share Leads With Microsoft
+#### Share Leads with Microsoft
 
 Once your solution is published and Co-Sell ready, the next step is **sharing leads with Microsoft.** These are referred to as **Co-Sell Opportunities.**
 
 In a Co-Sell opportunity, one or more Microsoft sales representatives actively engage in a deal to help solve a customer problem. Co-Sell opportunities can originate from a customer account when a Microsoft sales representative invites a partner to participate in Co-Selling. Co-Sell opportunities can also originate from a partner who needs more help from Microsoft sales to close a deal.
 
-Use **[this page](https://learn.microsoft.com/en-us/partner-center/manage-co-sell-opportunities)** to learn how to upload opportunities.
+Use **[this page](https://learn.microsoft.com/en-us/partner-center/referrals/manage-co-sell-opportunities)** to learn how to upload opportunities.
 
-#### Understand Marketplace Rewards
+#### Understand Marketplace Rewards for ISVs
 
-As you begin to sell through the Azure Marketplace, you are able to take advantage of Sales and Marketing benefits provided by Microsoft. Microsoft offers many programs for Partners. 
+As you begin to sell your ISV offers through the Azure Marketplace, you are able to take advantage of Sales and Marketing benefits provided by Microsoft. Microsoft offers many programs for Partners. 
 
 Membership workspace in Partner Center is a "single stop shop" where you can manage multiple memberships with Microsoft. We offer **[programs for different types of partners](https://learn.microsoft.com/en-us/partner-center/mpn-overview#explore-different-tracks).** 
 
 Different memberships come with different benefits provided by Microsoft. These benefits can be redeemed from Benefits workspace, including Azure Credits, Cloud Services, Software Keys, Technical consultations, Developer Tools, Marketing Benefits & Logo Builder.
 
   - [Guide to Redeem Marketplace Benefits](https://learn.microsoft.com/en-us/partner-center/mpn-learn-about-go-to-market-benefits)  
-  - For ISV partners, learn more about the [ISV Success Program](https://onedrive.live.com/view.aspx?resid=6C423AE231DA44BB!2126&ithint=file%2cpptx&wdo=2&authkey=!AN7rkGIrJ72JoMs) 
+  - Learn more about the [ISV Success Program](https://onedrive.live.com/view.aspx?resid=6C423AE231DA44BB!2126&ithint=file%2cpptx&wdo=2&authkey=!AN7rkGIrJ72JoMs) 
 
 ### Next Steps
-Before moving on to the next section you should have: 
--  [x] A published offer in the Microsoft Marketplace.
+If you are an ISV partner you should have completed the following steps before moving on to the next section
+-  [x] A published offer in the Microsoft Commercial Marketplace.
 -  [x] Uploaded the collateral needed to Co-Sell with Microsoft.
 -  [x] Shared at least 1 Co-Sell opportunity with Microsoft through Partner Center.
 -  [x] Read and understand the potential of Marketplace rewards & redeemed your Marketplace benefits.

--- a/_docs/Skilling/Partner Onboarding Academy/Onboard.md
+++ b/_docs/Skilling/Partner Onboarding Academy/Onboard.md
@@ -2,7 +2,7 @@
 layout: page
 title: Onboard 
 description: How to Onboard onto your Partner Journey
-updated: 2024-02-22
+updated: 2024-09-06
 permalink: /skilling/partner-onboarding-academy/onboard
 showbreadcrumb: true
 ---
@@ -14,25 +14,29 @@ The Microsoft Partner Onboarding Academy's **Modules** are organized into sectio
 
 ![](../../../assets/partner-onboarding/partner-journey-onboard.png)
 
-### Onboarding onto the Azure Marketplace
+### Onboarding onto the Microsoft AI Cloud Partner Program
 
 The following steps will help you onboard your Partner Onboarding journey:
 
 1. Choose an existing Microsoft Entra tenant or **[create a new one](https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/create-new-tenant).**
 1. **[Enroll in Partner Center Account with the tenant](/PartnerResources/skilling/partner-onboarding-academy/acct)** — Microsoft Partner Center is a portal and platform provided by Microsoft for its partners.
-1. **[Join Microsoft AI Cloud Partner Program and Commercial Marketplace Program](https://learn.microsoft.com/en-us/partner-center/intro-to-cloud-partner-program-membership)** — There are many partner programs. If you are looking to build and transact a solution on Azure Marketplace, join these programs.
-    - NOTE: By joining the Commercial Marketplace Program, you are automatically enrolled in the Microsoft AI Cloud Partner Program as well.
-1. **[Add Publishers in the Commercial Marketplace](https://learn.microsoft.com/en-us/partner-center/add-publishers)**
+1. **[Join Microsoft AI Cloud Partner Program](https://learn.microsoft.com/en-us/partner-center/intro-to-cloud-partner-program-membership)** — There are many partner programs.
+    - If you are looking to build and transact a solution on Azure Marketplace, join the [Commercial Marketplace Program](https://learn.microsoft.com/en-us/partner-center/account-settings/create-account).
+    - If you are looking to sell Microsoft cloud services, explore the [Cloud Solution Provider program](https://learn.microsoft.com/en-us/partner-center/enroll/enrolling-in-the-csp-program) once onboarded.
 1. **[Complete Partner Center account verification](https://learn.microsoft.com/en-us/partner-center/verification-responses)**
 1. **[Update Tax and Payment Profile](https://learn.microsoft.com/en-us/partner-center/set-up-your-payout-account)**
-1. **[Complete Business Profile](https://learn.microsoft.com/en-us/partner-center/create-a-marketing-profile)** **(OPTIONAL)**
-1. Active Resources to Grow Business **(OPTIONAL)**
-  - While this can be done later in your partner journey, enrolling in these programs will help you in the future.
-  - **[Microsoft Action Pack](https://partner.microsoft.com/en-us/partnership/action-pack):** Software, support, and benefits for businesses that want to start, build, and grow their Microsoft practice.
-    - **[Follow these steps to purchase](https://learn.microsoft.com/en-us/partner-center/mpn-get-action-pack)**
-    - **[Meet Criteria for Solutions Partner Designation](https://learn.microsoft.com/en-us/partner-center/introduction-to-pcs)**
-    - Specializations and expert programs give solutions partners a way to differentiate their organizations by demonstrating deep technical expertise along with experience in specific technical scenarios under each solution area.
-    - **[Learn about other benefits in Partner Center](https://learn.microsoft.com/en-gb/partner-center/manage-your-partner-network-benefits):** Azure Credits, Cloud Services, Software Keys, Technical consultations, Developer Tools, Marketing Benefits & Logo Builder.
+1. **[Complete Business Profile](https://learn.microsoft.com/en-us/partner-center/create-a-marketing-profile)**
+1. **[Add Publishers in the Commercial Marketplace](https://learn.microsoft.com/en-us/partner-center/add-publishers)** if you enrolled in the Commercial Marketplace program
+1. Active Resources to Grow Business **(OPTIONAL)** - While this can be done later in your partner journey, enrolling in these programs will help you in the future.
+- **[Partner Success Core](https://learn.microsoft.com/en-us/partner-center/membership/partner-success-core-benefits)** or **[Partner Success Expanded](https://learn.microsoft.com/en-us/partner-center/membership/partner-success-expanded-benefits)** benefits for **Services** and **Channel** partners: Software, support, and benefits for businesses that want to start, build, and grow their Microsoft practice.
+  - Follow the steps to [purchase Partner Success Core](https://learn.microsoft.com/en-us/partner-center/membership/partner-success-core-benefits#purchase-partner-success-core-benefits) or [purchase Partner Success Expanded](https://learn.microsoft.com/en-us/partner-center/membership/partner-success-expanded-benefits#purchase-partner-success-expanded-benefits) benefits.
+  - **[Meet Criteria for Solutions Partner Designation](https://learn.microsoft.com/en-us/partner-center/membership/introduction-to-pcs)**
+    - Specializations and Designations give Services and Channel partners a way to differentiate their organizations by demonstrating deep technical expertise along with experience in specific technical scenarios under each solution area.
+- **[ISV Success Build and Publish](https://learn.microsoft.com/en-us/partner-center/membership/isv-success)** benefits for **ISV** partners: Benefits to assist with the building, deployment, publishing, and selling of your application.
+  - Follow the steps to [purchase ISV Success Build and Publish](https://learn.microsoft.com/en-us/partner-center/membership/isv-success#enrollment) benefits
+  - **[Meet Criteria for Solutions Partner with Certified Software](https://learn.microsoft.com/en-us/partner-center/referrals/solutions-partner-certified-software-designations-benefits)**
+    - Certified Software validates the capability of your solution, increases discoverability with Microsoft customers and sellers, and unlocks go-to-market, sales, and marketing benefits.
+- **[Learn about other benefits in Partner Center](https://learn.microsoft.com/en-us/partner-center/benefits/manage-your-partner-network-benefits):** Azure Credits, Cloud Services, Software Keys, Technical consultations, Developer Tools, Marketing Benefits & Logo Builder.
 
 ### Next Steps
 

--- a/_docs/Skilling/Partner Onboarding Academy/Partner Center Acct.md
+++ b/_docs/Skilling/Partner Onboarding Academy/Partner Center Acct.md
@@ -3,7 +3,7 @@ layout: page
 title: Create a Partner Center Account
 description: Want to begin your partner journey?
 permalink: /skilling/partner-onboarding-academy/acct
-updated: 2023-11-14
+updated: 2024-09-06
 showbreadcrumb: true
 tags: 
 - academy content
@@ -21,7 +21,7 @@ Partner Center serves as the central hub for partners to manage their relationsh
 
 Key Features & Functionalities:
 
-- __Account Management__: Partners can use Partner Center to manage their Microsoft Partner Network (MPN) accounts. This includes updating company information, managing user access, and maintaining a record of their Microsoft certifications and competencies.
+- __Account Management__: Partners can use Partner Center to manage their Microsoft AI Cloud Partner Program (MAICPP) accounts. This includes updating company information, managing user access, and maintaining a record of their Microsoft certifications and competencies.
 
 - __Business Profile__: Partners can create and maintain a business profile within Partner Center, which allows them to showcase their expertise, certifications, and competencies to potential customers.
 
@@ -35,7 +35,7 @@ Key Features & Functionalities:
 
 - __Incentives and Rebates__: Partner Center provides information on incentive programs and rebates that partners may be eligible for based on their sales and performance.
 
-- __Competencies and Certifications__: Partners can track their progress in achieving Microsoft competencies and certifications, which can help them demonstrate expertise in specific Microsoft technologies.
+- __Designations, Specializations, and Certifications__: Partners can track their progress in achieving Microsoft Solution Designations, Specializations, and certifications, which can help them demonstrate expertise in specific Microsoft technologies.
 
 - __Analytics and Reporting__: Partners can access analytics and reporting tools to monitor their business performance, customer usage, and sales trends.
 
@@ -56,7 +56,7 @@ You will need to provide:
 
 Once submitted, Microsoft will **[validate the account](https://learn.microsoft.com/en-us/partner-center/verification-responses).**  Once complete, you will have:
 
-   - MPN ID
+   - Partner ID
    - Verified Account
 
 #### Additional Resources

--- a/_docs/Skilling/Partner Onboarding Academy/index.md
+++ b/_docs/Skilling/Partner Onboarding Academy/index.md
@@ -2,7 +2,7 @@
 layout: page
 title: Microsoft Partner Onboarding Academy
 description: Microsoft Partner Onboarding Academy
-updated: 2024-02-22
+updated: 2024-09-06
 permalink: /skilling/partner-onboarding-academy
 showbreadcrumb: true
 ---
@@ -18,17 +18,19 @@ There are multiple types of partnerships with Microsoft:
 * Engineering Partnership — Launching a joint technical project
 * Co-Sell / GTM — Primary focus of this Academy
 
-### Why be a Microsoft Partner?
+### Why become a Microsoft Partner?
 
-- Integrated Billing for Customers
-  - Customer likely has existing billing setup with Microsoft
-  - Approving new Purchase Orders for customer can take months
-- Customers can use eligible Partner solutions to **[decrement MACC](https://learn.microsoft.com/en-us/azure/cost-management-billing/manage/track-consumption-commitment?tabs=portal)**
-- Microsoft is huge and our Partner network is even bigger...
-  - **[For every $1 of Microsoft revenue, ISV's make $10](https://blogs.partner.microsoft.com/partner/microsoft-ecosystem-value-new-data-reveals-partner-paths-to-profitability-and-growth/)**
-  - [Many benefits](https://learn.microsoft.com/en-us/partner-center/manage-your-partner-network-benefits)
-  - [Many incentives](https://partner.microsoft.com/en-us/partnership/partner-incentives)
-  - [Many program resources](https://partner.microsoft.com/en-US/resources)
+- Access to Resources and Support
+  - Access [resources](https://partner.microsoft.com/en-US/resources), programs, and [benefits](https://learn.microsoft.com/en-us/partner-center/manage-your-partner-network-benefits) that empower partners to capture opportunities
+  - Access to training, technical support, and marketing resources
+- Accelerate Business Growth
+  - Reach more customers and expand into new markets
+  - Reward your success and help you drive even greater profitability with [incentive programs](https://aka.ms/partnerincentives)
+  - Sell the full range of Microsoft cloud services through the [Cloud Solution Provider program](https://learn.microsoft.com/en-us/partner-center/enroll/csp-overview).
+  - **[For every $1 of Microsoft revenue, Services partners make $7 and ISV's make $10](https://blogs.partner.microsoft.com/partner/microsoft-ecosystem-value-new-data-reveals-partner-paths-to-profitability-and-growth/)**
+- Access to Microsoft's Commercial Marketplace
+   - Gain visibility to millions of Microsoft customers
+   - Simplify procurement while helping customers **[decrement MACC](https://learn.microsoft.com/en-us/azure/cost-management-billing/manage/track-consumption-commitment?tabs=portal)** with eligible partner solutions
 
 ### The Microsoft Partner Onboarding Academy's **Modules** are organized into sections which reflect the typical partner journey:
 
@@ -43,21 +45,21 @@ There are multiple types of partnerships with Microsoft:
 
 #### Key Concepts
 
-NOTE: Microsoft uses many acronyms in its business. Use **[this page](/PartnerResources/skilling/partner-onboarding-academy/acronyms)** to reference those most commonly used.
+NOTE: Microsoft uses many acronyms. Use **[this page](/PartnerResources/skilling/partner-onboarding-academy/acronyms)** to understand the most common acronyms.
 
 Below are key concepts and definitions you'll see used in this Academy: 
 
 * [Partner Center](https://learn.microsoft.com/en-us/partner-center/overview): A portal for Partners to manage their account, offers, customers, and billing.
-* [Azure Marketplace](https://azuremarketplace.microsoft.com/en-US/): Where customers can purchase offers.
+* [Microsoft Commercial Marketplace](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/overview#commercial-marketplace-online-stores): Where customers discover and purchase your solutions.
 * [Offer](https://learn.microsoft.com/en-us/partner-center/marketplace/publisher-guide-by-offer-type): Software or service that the customer purchases (i.e., solutions).
-* [Co-Sell](https://en.wikipedia.org/wiki/Cross-selling): Selling with Microsoft.
+* [Co-Sell](https://learn.microsoft.com/en-us/partner-center/referrals/co-sell-overview): Selling with Microsoft.
  
 Partner types:
 
 - [ISV](https://en.wikipedia.org/wiki/Independent_software_vendor): Independent Software Vendor
   - Use **[this page](/PartnerResources/skilling/partner-onboarding-academy/isv)**  to see some ISV specific benefits and programs
 - [SI](https://en.wikipedia.org/wiki/Systems_integrator): Systems Integrator
-- [CSP](https://learn.microsoft.com/en-us/partner-center/enrolling-in-the-csp-program): Cloud Service Providers
+- [Channel](https://en.wikipedia.org/wiki/Channel_partner): Scale Solution Providers, Managed Service Providers, Hosters, Indirect Providers, and Telecos
 
 ### How does a Partner get started?
 
@@ -72,6 +74,6 @@ Have questions not addressed here? See our **[FAQ](/PartnerResources/skilling/pa
 * [Six easy steps to becoming a Microsoft Partner](https://www.microsoft.com/en-us/americas-partner-blog/2023/06/15/six-easy-steps-to-becoming-a-microsoft-partner/)
 * [Carve Partners: Partner Center Guide for ISVs](https://www.linkedin.com/posts/reis-barrie-13414656_carve-partner-center-guide-for-isvs-activity-7118183761975889920-xAII/)
 * [Mastering the Marketplace](https://aka.ms/masteringthemarketplace)
-* [Journey Maps](https://partner.microsoft.com/en-us/resources/collection/microsoft-transformational-changes#/): Provides the vision, critical milestones, and details about each milestone for key initiatives
+* [Journey Maps](https://partner.microsoft.com/en-us/resources/collection/microsoft-transformational-changes#/): Provides the vision, key milestones, and details to help you navigate the transformational changes in Microsoft programs.
 * [Operational Readiness](https://partner.microsoft.com/en-US/resources): Provides the “how to”, playbooks, and detailed components
 * [Community Calls](https://globalpbocomm.eventbuilder.com/PartnerBusinessOperationsWebinars?source=JM): Provides partners an opportunity to connect with the SMEs and to ask questions


### PR DESCRIPTION
- Updated CSP and MCPP Acronyms
- Change Partner Incentives to aka.ms Link
- Corrected Partner Capability Score Link
- Updated Partner Types to Change from CSP to Channel
- Refreshed Partner Value Proposition
- Added a Skilling section to the Build module
- Updated the MAICPP Packages in the Onboard module
- Added additional Services/Channel partner focus in the Onboard module
- Updated naming from Consulting Services to Professional Services
- Removed IoT Edge module as a valid offer type
- Added M365 offer type
- Added steps to increase Co-sell visibility
- Improved readability on the FAQ page
- Updated references to MPN and MPN ID to MAICPP and Partner ID